### PR TITLE
Add: HeaderSetter, OneAgentInfo, TraceContextInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,22 @@ All interactions with the OneAgentSDK are done via a central interface. You can 
 OneAgentSDK oneAgentSDK = OneAgentSDKFactory.createInstance();
 ```
 
-You can create more than one object of this in your application. This ensures that you do not need to coordinate a singleton behavior across the whole applications and that different frameworks can use the SDK independently from each other. The OneAgentSDK object enables you to create Tracers for different aspects of your application.
+You can create more than one object of this in your application. This ensures that you do not need to coordinate a singleton behavior across the whole application and that different frameworks can use the SDK independently from each other. The OneAgentSDK object enables you to create Tracers for different aspects of your application.
+
+<a name="tracecontext"></a>
+
+## Trace Context
+
+An instance of the `OneAgentSDK` provides access to the *Trace-Id* and *Span-Id* information
+of the current PurePath node. This information can then be used to provide e.g. additional
+context in log messages.
+
+```Java
+TraceContextInfo traceContextInfo = oneAgentSDK.getTraceContextInfo();
+String traceId = getTraceContextInfo.getTraceId();
+String spanId = getTraceContextInfo.getSpanId();
+logger.info("[!dt dt.trace_id={},dt.span_id={}] sending request ...", traceId, spanId);
+```
 
 <a name="tracers"></a>
 

--- a/api/com/dynatrace/oneagent/sdk/api/HeaderSetter.java
+++ b/api/com/dynatrace/oneagent/sdk/api/HeaderSetter.java
@@ -1,0 +1,15 @@
+package com.dynatrace.oneagent.sdk.api;
+
+/**
+ * This interface is used for setting headers (key-value pairs)
+ */
+public interface HeaderSetter<Carrier> {
+	/**
+	 * Sets the value for the specified name. If a header with this name already exists, the value is overwritten.
+	 * @param name a valid HTTP header name, never null or empty
+	 * @param value the header value to be set, never null
+	 * @param carrier the header carrier (i.e., the web request object or its map of headers),
+	 *                forwarded as it is passed to the calling method (could be null therefore)
+	 */
+  void setHeader(String name, String value, Carrier carrier);
+}

--- a/api/com/dynatrace/oneagent/sdk/api/IncomingMessageReceiveTracer.java
+++ b/api/com/dynatrace/oneagent/sdk/api/IncomingMessageReceiveTracer.java
@@ -4,6 +4,6 @@ package com.dynatrace.oneagent.sdk.api;
  * Interface for receiving message tracer.
  * <a href="https://github.com/Dynatrace/OneAgent-SDK#messaging">https://github.com/Dynatrace/OneAgent-SDK#messaging</a>
  */
-public interface IncomingMessageReceiveTracer extends Tracer, Joinable {
+public interface IncomingMessageReceiveTracer extends Tracer {
 	
 }

--- a/api/com/dynatrace/oneagent/sdk/api/OneAgentSDK.java
+++ b/api/com/dynatrace/oneagent/sdk/api/OneAgentSDK.java
@@ -5,10 +5,11 @@ import com.dynatrace.oneagent.sdk.api.enums.ChannelType;
 import com.dynatrace.oneagent.sdk.api.enums.MessageDestinationType;
 import com.dynatrace.oneagent.sdk.api.enums.MessageSystemVendor;
 import com.dynatrace.oneagent.sdk.api.enums.SDKState;
-import com.dynatrace.oneagent.sdk.api.enums.OneAgentInfo;
 import com.dynatrace.oneagent.sdk.api.infos.DatabaseInfo;
-import com.dynatrace.oneagent.sdk.api.infos.WebApplicationInfo;
 import com.dynatrace.oneagent.sdk.api.infos.MessagingSystemInfo;
+import com.dynatrace.oneagent.sdk.api.infos.OneAgentInfo;
+import com.dynatrace.oneagent.sdk.api.infos.WebApplicationInfo;
+import com.dynatrace.oneagent.sdk.api.infos.TraceContextInfo;
 
 /**
  * Interface implemented by OneAgentSDK. Retrieved by {@link OneAgentSDKFactory#createInstance()}. For details see:
@@ -106,7 +107,7 @@ public interface OneAgentSDK {
 	 * @param serviceEndpoint	logical deployment endpoint on the server side
 	 *							In case of a clustered/load balanced service, the serviceEndpoint represents the common logical endpoint (e.g. registry://staging-environment/myservices/serviceA) where as the @channelEndpoint represents the actual communication endpoint. As such a single serviceEndpoint can have many channelEndpoints.
 	 * @param channelType		communication protocol used by remote call
-	 * @param channelEndpoint	this represents the communication endpoint for the remote service. This information allows Dynatrace to tie the database requests to a specific process or cloud service. It is optional.
+	 * @param channelEndpoint	this represents the communication endpoint for the remote service. It is optional.
 	 * 							* for TCP/IP: host name/IP of the server-side (can include port)
 	 * 							* for UNIX domain sockets: path of domain socket file
 	 * 							* for named pipes: name of pipe
@@ -162,7 +163,7 @@ public interface OneAgentSDK {
 	 * Does exactly the same as {@link #addCustomRequestAttribute(String, String)}, but request-attribute type double.
 	 */
 	void addCustomRequestAttribute(String key, double value);
-	
+
 	// ***** Messaging (outgoing & incoming) *****
 
 	/**
@@ -189,7 +190,7 @@ public interface OneAgentSDK {
 	OutgoingMessageTracer traceOutgoingMessage(MessagingSystemInfo messagingSystem);
 
 	/**
-	 * Creates tracer for an incoming asynchronous message (receive).
+	 * Creates a tracer for an incoming asynchronous message (blocking receive).
 	 * 
 	 * @param messagingSystem	information about the messaging system (see createMessagingSystemInfo methods).
 	 * @return {@link IncomingMessageReceiveTracer} to work with
@@ -197,7 +198,7 @@ public interface OneAgentSDK {
 	IncomingMessageReceiveTracer traceIncomingMessageReceive(MessagingSystemInfo messagingSystem);
 	
 	/**
-	 * Creates tracer for processing (consuming) an received message (onMessage).
+	 * Creates a tracer for processing (consuming) a received message (onMessage).
 	 * 
 	 * @param messagingSystem	information about the messaging system (see createMessagingSystemInfo methods).
 	 * @return {@link IncomingMessageProcessTracer} to work with
@@ -214,7 +215,7 @@ public interface OneAgentSDK {
 	 * @return {@link CustomServiceTracer} to work with
 	 */
 	CustomServiceTracer traceCustomService(String serviceMethod, String serviceName);
-	
+
 	// ***** various *****
 
 	/**
@@ -239,4 +240,11 @@ public interface OneAgentSDK {
      */
     void setLoggingCallback(LoggingCallback loggingCallback);
 
+    /**
+     * Returns information about the current PurePath node using the TraceContext
+		 * (Trace-Id, Span-Id) model as defined in https://www.w3.org/TR/trace-context.
+		 *  
+     * @return see {@link TraceContextInfo} for more details. Never returns null.
+     */
+    TraceContextInfo getTraceContextInfo();
 }

--- a/api/com/dynatrace/oneagent/sdk/api/OutgoingMessageTracer.java
+++ b/api/com/dynatrace/oneagent/sdk/api/OutgoingMessageTracer.java
@@ -12,12 +12,12 @@ public interface OutgoingMessageTracer extends Tracer, OutgoingTaggable {
 	 * @param vendorMessageId the messageId
 	 */
 	public void setVendorMessageId(String vendorMessageId);
-	
+
 	/**
 	 * Adds optional information about a traced message: correlation id used by messaging system.
 	 *  
 	 * @param correlationId correlationId
 	 */
 	public void setCorrelationId(String correlationId);
-	
+
 }

--- a/api/com/dynatrace/oneagent/sdk/api/OutgoingWebRequestTracer.java
+++ b/api/com/dynatrace/oneagent/sdk/api/OutgoingWebRequestTracer.java
@@ -11,7 +11,7 @@ public interface OutgoingWebRequestTracer extends Tracer, OutgoingTaggable {
 	void addRequestHeader(String name, String value);
 
 	/**
-	 * All HTTP response headers returned by the server should be provided to this method. Selective capturing will 
+	 * All HTTP response headers returned by the server should be provided to this method. Selective capturing will
 	 * be done based on sensor configuration.
 	 *
 	 * @param name		HTTP response header field name
@@ -25,5 +25,26 @@ public interface OutgoingWebRequestTracer extends Tracer, OutgoingTaggable {
 	 * @param statusCode		HTTP status code retrieved from server
 	 */
 	void setStatusCode(int statusCode);
+
+	/**
+	 * <p> Sets HTTP request headers required for linking requests end-to-end.
+	 * <p> This method can only be called on an active tracer (i.e., between start and end).
+	 *
+	 * <p> Based on your configuration, this method will add the 'X-dynaTrace' header and/or the W3C Trace Context headers ('traceparent' and 'tracestate').<br>
+	 * Therefore it is no longer necessary to manually add the Dynatrace tag and thus {@see #getDynatraceStringTag()}
+	 * must not be used together with this method.
+	 *
+	 * <blockquote>Example usage:
+	 * <pre>{@code
+	 *Map<String, String> requestHeaderFields = new HashMap<>();
+	 *outgoingWebRequestTracer.injectTracingHeaders((key, value, _carrier) -> requestHeaderFields.put(key, value), null);
+	 * // or as a stateless implementation:
+	 *outgoingWebRequestTracer.injectTracingHeaders((key, value, carrier) -> carrier.put(key, value), requestHeaderFields);
+	 * }</pre></blockquote>
+	 *
+	 * @param headerSetter An implementation of {@see HeaderSetter} which sets the respective headers on the HTTP request.
+	 * @param carrier The (nullable) header carrier object passed to {@code headerSetter} (i.e., the web request object or its map of headers)
+	 */
+	<Carrier> void injectTracingHeaders(HeaderSetter<Carrier> headerSetter, Carrier carrier);
 
 }

--- a/api/com/dynatrace/oneagent/sdk/api/enums/MessageSystemVendor.java
+++ b/api/com/dynatrace/oneagent/sdk/api/enums/MessageSystemVendor.java
@@ -15,7 +15,8 @@ public enum MessageSystemVendor {
 	WEBSPHERE("WebSphere"),
 	MQSERIES_JMS("MQSeries JMS"),
 	MQSERIES("MQSeries"),
-	TIBCO("Tibco");
+	TIBCO("Tibco"),
+	KAFKA("Apache Kafka");
 	
 	private String vendorName;
 	

--- a/api/com/dynatrace/oneagent/sdk/api/infos/OneAgentInfo.java
+++ b/api/com/dynatrace/oneagent/sdk/api/infos/OneAgentInfo.java
@@ -1,0 +1,26 @@
+package com.dynatrace.oneagent.sdk.api.infos;
+
+/**
+ * Provides more details about the OneAgent used by the SDK.
+ */
+public interface OneAgentInfo {
+
+	/**
+	 * Checks if agent is available. 
+	 *  
+	 * @return true if agent has been found - even if it is not compatible with this SDK version.
+	 */
+	boolean agentFound();
+
+	/**
+	 * Checks if found agent is compatible with this SDK version.
+	 * @return true if agent is available and compatible. False in any other case.
+	 */
+	boolean agentCompatible();
+	
+	/**
+	 * @return Version of agent found. Null in case of no agent or agent doesn't support reporting the version.  
+	 */
+	String version();
+
+}

--- a/api/com/dynatrace/oneagent/sdk/api/infos/TraceContextInfo.java
+++ b/api/com/dynatrace/oneagent/sdk/api/infos/TraceContextInfo.java
@@ -1,0 +1,38 @@
+package com.dynatrace.oneagent.sdk.api.infos;
+
+/**
+ * Provides information about the current PurePath node using the TraceContext
+ * (Trace-Id, Span-Id) model as defined in https://www.w3.org/TR/trace-context.
+ * The Span-Id represents the currently active PurePath node.
+ */
+public interface TraceContextInfo {
+	public static final String INVALID_TRACE_ID = "00000000000000000000000000000000";
+	public static final String INVALID_SPAN_ID = "0000000000000000";
+
+	/**
+	 * @return True if the value returned by {@link getTraceId()} is not equal to
+	 * {@link INVALID_TRACE_ID} and the value returned by {@link getSpanId}
+	 * is not equal to {@link INVALID_SPAN_ID}.
+	 */
+	boolean isValid();
+
+	/**
+	 * @return The Trace-Id represented as case-insensitive hex-encoded string
+	 * (see: https://tools.ietf.org/html/rfc4648#section-8).
+	 * {@link INVALID_TRACE_ID} in case of:
+	 * - No OneAgent is present.
+	 * - OneAgent doesn't support reporting the trace id.
+	 * - There is no currently active PurePath context.
+	 */
+	String getTraceId();
+
+	/**
+	 * @return The Span-Id represented as case-insensitive hex-encoded string
+	 * (see: https://tools.ietf.org/html/rfc4648#section-8).
+	 * {@link INVALID_SPAN_ID} in case of:
+	 * - No OneAgent is present.
+	 * - OneAgent doesn't support reporting the span id.
+	 * - There is no currently active PurePath context.
+	 */
+	String getSpanId();
+}

--- a/api/com/dynatrace/oneagent/sdk/samples/GeneralUsageSample.java
+++ b/api/com/dynatrace/oneagent/sdk/samples/GeneralUsageSample.java
@@ -2,7 +2,7 @@ package com.dynatrace.oneagent.sdk.samples;
 
 import com.dynatrace.oneagent.sdk.OneAgentSDKFactory;
 import com.dynatrace.oneagent.sdk.api.OneAgentSDK;
-import com.dynatrace.oneagent.sdk.api.enums.OneAgentInfo;
+import com.dynatrace.oneagent.sdk.api.infos.OneAgentInfo;
 
 /**
  * This sample shows the general usage of the SDK:

--- a/api/com/dynatrace/oneagent/sdk/samples/OutgoingWebRequestSample.java
+++ b/api/com/dynatrace/oneagent/sdk/samples/OutgoingWebRequestSample.java
@@ -26,11 +26,14 @@ public class OutgoingWebRequestSample {
 		outgoingWebRequestTracer.start();
 		try {
 			Map<String, String> headerFields = new HashMap<>();
-			
-			// add Dynatrace tag to request metadata to allow the agent in the web server to link the request together
-			String tag = outgoingWebRequestTracer.getDynatraceStringTag();
-			headerFields.put(OneAgentSDK.DYNATRACE_HTTP_HEADERNAME, tag);
-			
+
+			// add the Dynatrace tag or W3C Trace Context (based on your configuration) to request headers to allow
+			// the agent in the web server to link the request together for end-to-end tracing
+			// Option 1: passing a stateful lambda, directly accessing 'headerFields'
+			outgoingWebRequestTracer.injectTracingHeaders((key, value, _carrier) -> headerFields.put(key, value), null);
+			// Option 2: passing a stateless implementation, which gets 'headerFields' passed as carrier
+			outgoingWebRequestTracer.injectTracingHeaders((key, value, carrier) -> carrier.put(key, value), headerFields);
+
 			outgoingWebRequestTracer.setStatusCode(executeHttpGetRequest(url, headerFields));
 		} catch (Exception e) {
 			outgoingWebRequestTracer.error(e.getMessage());


### PR DESCRIPTION
Add missing concepts to this specification repository:
* Tracing headers injection (`HeaderSetter`).
* Extended agent state information (`OneAgentInfo`).
* Support for retrieving trace context information (`TraceContextInfo`).

Minor fixes and updates.