### PR TITLE
Update README.md to include reference to SDK for PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The language specific SDKs are open source and published directly to GitHub, tog
 * [OneAgent SDK for C/C++](https://github.com/Dynatrace/OneAgent-SDK-for-C)
 * [OneAgent SDK for Python](https://github.com/Dynatrace/OneAgent-SDK-for-Python)
 * [OneAgent SDK for .NET](https://github.com/Dynatrace/OneAgent-SDK-for-dotnet)
+* [OneAgent SDK for PHP](https://github.com/Dynatrace/OneAgent-SDK-for-PHP)
 
 The [Java API contained in this repository](https://github.com/Dynatrace/OneAgent-SDK/blob/master/api) is for design reference only. The actual Java API is available in the [OneAgent SDK for Java](https://github.com/Dynatrace/OneAgent-SDK-for-Java).
 


### PR DESCRIPTION
Adding a bulletpoint for the PHP SDK aligns with official documentation [here](https://docs.dynatrace.com/docs/ingest-from/extend-dynatrace/extend-tracing/oneagent-sdk#oneagent-sdk-on-github).